### PR TITLE
Added and integrated gnu-efi build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+OVMF_DIR = /usr/share/ovmf
+C_FLAGS := -m32 -fno-pie -ffreestanding
+
+all : os
+
+%.o : %.asm
+	nasm $< -f elf32 -o $@
+
+%.o : %.c
+	gcc ${C_FLAGS} -c $< -o $@
+
+src/kernel.bin : src/kernel.o src/kernel_entry.o
+	ld -m elf_i386 -o $@ -Ttext 0x1000 $^ 
+	#This should be in binary format but for some reason ld makes the binary ~140mb
+	
+os : src/kernel.bin
+	cd UEFI && $(MAKE)
+	
+run : os
+	sudo qemu-system-x86_64 -drive file=${OVMF_DIR}/OVMF.fd,format=raw,if=pflash -cdrom UEFI/main.iso
+	
+debug: src/kernel.bin
+	cd UEFI && $(MAKE) debug
+	sudo qemu-system-x86_64 -drive file=${OVMF_DIR}/OVMF.fd,format=raw,if=pflash -cdrom UEFI/debug.iso
+	
+clean:
+	rm -fr src/kernel.bin src/kernel_entry.o src/kernel.o
+	cd UEFI && $(MAKE) clean

--- a/UEFI/Makefile
+++ b/UEFI/Makefile
@@ -65,6 +65,11 @@ all: ${TARGET}.iso
 	mmd -i $@ ::/EFI
 	mmd -i $@ ::/EFI/BOOT
 	mcopy -i $@ BOOTX64.EFI ::/EFI/BOOT
+	
+	#put the kernel into the image #########
+	mcopy -i $@ ../src/kernel.bin ::/
+	# this may be temporary ################
+	
 	rm -fr BOOTX64.EFI
 	rm -fr $<
 
@@ -81,6 +86,7 @@ debug.iso : ${TARGET}.efi.debug debug.img
 	mv ${TARGET}.efi.debug ${TARGET}.efi
 	mmd -i debug.img ::/EFI/TEST
 	mcopy -i debug.img ${TARGET}.efi ::/EFI/TEST
+	
 	mkdir -p iso
 	cp debug.img iso
 	xorriso -as mkisofs -R -f -e debug.img -no-emul-boot -o $@ iso

--- a/UEFI/Makefile
+++ b/UEFI/Makefile
@@ -1,0 +1,97 @@
+#https://wiki.osdev.org/UEFI_App_Bare_Bones#Running_as_a_USB_stick_image
+
+#run before using this file
+# $git clone https://git.code.sf.net/p/gnu-efi/code gnu-efi
+# $cd gnu-efi
+# $make
+
+
+GNUEFI_DIR = gnu-efi
+OVMF_DIR = /usr/share/ovmf
+
+# .c that gets made into the .efi program
+TARGET = main
+
+
+include $(GNUEFI_DIR)/Make.defaults
+INCDIR = -I$(GNUEFI_DIR) -I$(GNUEFI_DIR)/inc -I$(GNUEFI_DIR)/inc/$(ARCH) \
+           -I$(GNUEFI_DIR)/inc/protocol
+
+include $(GNUEFI_DIR)/Make.rules
+
+#### THE FOLLOWING IS TAKEN FROM gnu-efi/apps/Makefile with modifications ####
+
+#modified paths to fit with this Makefile
+#order and spacing has also been modified
+
+CRTOBJS = $(GNUEFI_DIR)/$(ARCH)/gnuefi/crt0-efi-$(ARCH).o
+LINUX_HEADERS = /usr/src/sys/build
+CPPFLAGS += -D__KERNEL__ -I$(LINUX_HEADERS)/include
+
+LDSCRIPT	= $(GNUEFI_DIR)/gnuefi/elf_$(ARCH)_efi.lds
+ifneq (,$(findstring FreeBSD,$(OS)))
+LDSCRIPT	= $(GNUEFI_DIR)/gnuefi/elf_$(ARCH)_fbsd_efi.lds
+endif
+
+LDFLAGS		+= -shared -Bsymbolic -L$(GNUEFI_DIR)/$(ARCH)/ -L$(GNUEFI_DIR)/$(ARCH)/gnuefi/ -T $(LDSCRIPT) $(CRTOBJS)
+
+LOADLIBES	+= -l/libefi -lgnuefi
+LOADLIBES	+= $(LIBGCC)
+
+ifneq ($(HAVE_EFI_OBJCOPY),)
+
+FORMAT		:= --target efi-app-$(ARCH)
+$(TARGET_BSDRIVERS): FORMAT=--target efi-bsdrv-$(ARCH)
+$(TARGET_RTDRIVERS): FORMAT=--target efi-rtdrv-$(ARCH)
+
+else
+
+SUBSYSTEM	:= 0xa
+$(TARGET_BSDRIVERS): SUBSYSTEM = 0xb
+$(TARGET_RTDRIVERS): SUBSYSTEM = 0xc
+
+FORMAT		:= -O binary
+LDFLAGS		+= --defsym=EFI_SUBSYSTEM=$(SUBSYSTEM)
+
+endif
+##############################################################################
+
+all: ${TARGET}.iso
+
+%.img : %.efi
+	mv $< BOOTX64.EFI
+	dd if=/dev/zero of=$@ bs=1k count=1440
+	mformat -i $@ -f 1440 ::
+	mmd -i $@ ::/EFI
+	mmd -i $@ ::/EFI/BOOT
+	mcopy -i $@ BOOTX64.EFI ::/EFI/BOOT
+	rm -fr BOOTX64.EFI
+	rm -fr $<
+
+%.iso : %.img
+	mkdir -p iso
+	cp $< iso
+	xorriso -as mkisofs -R -f -e $< -no-emul-boot -o $@ iso
+	rm -r iso
+	rm -fr $< *.so *.o
+
+#the debug iso uses a program that does nothing to get directly into the GUI
+#the target can be run from a file via the GUI
+debug.iso : ${TARGET}.efi.debug debug.img
+	mv ${TARGET}.efi.debug ${TARGET}.efi
+	mmd -i debug.img ::/EFI/TEST
+	mcopy -i debug.img ${TARGET}.efi ::/EFI/TEST
+	mkdir -p iso
+	cp debug.img iso
+	xorriso -as mkisofs -R -f -e debug.img -no-emul-boot -o $@ iso
+	rm -r iso
+	rm -fr *.efi *.img *.so *.o
+	
+debug : debug.iso
+	sudo qemu-system-x86_64 -drive file=${OVMF_DIR}/OVMF.fd,format=raw,if=pflash -cdrom debug.iso
+	
+run : ${TARGET}.iso
+	sudo qemu-system-x86_64 -drive file=${OVMF_DIR}/OVMF.fd,format=raw,if=pflash -cdrom $<
+	
+clean:
+	rm -fr *.iso *.efi *.img *.efi.debug

--- a/UEFI/debug.c
+++ b/UEFI/debug.c
@@ -1,0 +1,10 @@
+#include <efi.h>
+#include <efilib.h>
+ 
+EFI_STATUS
+efi_main (EFI_HANDLE image_handle, EFI_SYSTEM_TABLE *systab)
+{
+	InitializeLib(image_handle, systab);
+	Print(L"Hello, world!\n");
+	return EFI_SUCCESS;
+}

--- a/UEFI/main.c
+++ b/UEFI/main.c
@@ -1,0 +1,10 @@
+#include <efi.h>
+#include <efilib.h>
+ 
+EFI_STATUS
+efi_main (EFI_HANDLE image_handle, EFI_SYSTEM_TABLE *systab)
+{
+	InitializeLib(image_handle, systab);
+	Print(L"Hello, world!\n");
+	return EFI_SUCCESS;
+}

--- a/UEFI/main.c
+++ b/UEFI/main.c
@@ -1,10 +1,55 @@
 #include <efi.h>
 #include <efilib.h>
  
-EFI_STATUS
-efi_main (EFI_HANDLE image_handle, EFI_SYSTEM_TABLE *systab)
+// https://wiki.osdev.org/Loading_files_under_UEFI
+EFI_FILE_HANDLE GetVolume(EFI_HANDLE image)
+{
+  EFI_LOADED_IMAGE *loaded_image = NULL;                  /* image interface */
+  EFI_GUID lipGuid = EFI_LOADED_IMAGE_PROTOCOL_GUID;      /* image interface GUID */
+  EFI_FILE_IO_INTERFACE *IOVolume;                        /* file system interface */
+  EFI_GUID fsGuid = EFI_SIMPLE_FILE_SYSTEM_PROTOCOL_GUID; /* file system interface GUID */
+  EFI_FILE_HANDLE Volume;                                 /* the volume's interface */
+ 
+  /* get the loaded image protocol interface for our "image" */
+  uefi_call_wrapper(BS->HandleProtocol, 3, image, &lipGuid, (void **) &loaded_image);
+  /* get the volume handle */
+  uefi_call_wrapper(BS->HandleProtocol, 3, loaded_image->DeviceHandle, &fsGuid, (VOID*)&IOVolume);
+  uefi_call_wrapper(IOVolume->OpenVolume, 2, IOVolume, &Volume);
+  return Volume;
+}
+
+UINT64 FileSize(EFI_FILE_HANDLE FileHandle)
+{
+  UINT64 ret;
+  EFI_FILE_INFO *FileInfo;         /* file information structure */
+  /* get the file's size */
+  FileInfo = LibFileInfo(FileHandle);
+  ret = FileInfo->FileSize;
+  FreePool(FileInfo);
+  return ret;
+}
+ 
+EFI_STATUS efi_main (EFI_HANDLE image_handle, EFI_SYSTEM_TABLE *systab)
 {
 	InitializeLib(image_handle, systab);
-	Print(L"Hello, world!\n");
+	EFI_FILE_HANDLE Volume = GetVolume(image_handle);
+	
+	CHAR16 *FileName = L"kernel.bin";
+ 	EFI_FILE_HANDLE FileHandle;
+
+	uefi_call_wrapper(Volume->Open, 5, Volume, &FileHandle, FileName, EFI_FILE_MODE_READ, EFI_FILE_READ_ONLY | EFI_FILE_HIDDEN | EFI_FILE_SYSTEM);
+	
+	UINT64 ReadSize = FileSize(FileHandle);
+	UINT8 *Buffer = AllocatePool(ReadSize);
+ 
+  	uefi_call_wrapper(FileHandle->Read, 3, FileHandle, &ReadSize, Buffer);
+	uefi_call_wrapper(FileHandle->Close, 1, FileHandle);
+	
+	// I'm so sorry for what I'm about to do
+	void* kernel = (void*)(Buffer);
+	kernel += 0x1000; // _start
+	void (*entry)(uint64_t) = (void (*)(uint64_t))(kernel);
+	entry(ReadSize);
+	//EFI_BOOT_SERVICES.Exit();
 	return EFI_SUCCESS;
 }

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,0 +1,7 @@
+#include "kernel.h"
+
+#include <stdint.h>
+
+void kernel_main(uint64_t kernel_size) {
+	while (1 == 1) {}	
+}

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -1,0 +1,4 @@
+#ifndef _KERNEL_H
+#define _KERNEL_H
+
+#endif

--- a/src/kernel_entry.asm
+++ b/src/kernel_entry.asm
@@ -1,0 +1,7 @@
+global _start;
+[bits 32]
+
+_start:
+    [extern kernel_main] ; Define calling point. Must have same name as kernel.c 'main' function
+    call kernel_main ; Calls the C function. The linker will know where it is placed in memory
+    jmp $


### PR DESCRIPTION
There is probably some licensing stuff that needs to be figured out.
- install qemu and ovmf
- Clone gnu-efi (the commands are at the top of the Makefile)
- build target is at the top of Makefile (filename without .c)
- run `$ make run` to run with qemu
- run `$ make debug` to debug with qemu
- "Debugging" brings you into OVMF's GUI and you can run the target .efi from ::/EFI/TEST/